### PR TITLE
add: gfortran library path on macOS.

### DIFF
--- a/Makefile.code
+++ b/Makefile.code
@@ -25,6 +25,7 @@ RANLIB ?= /usr/bin/ranlib
 ifeq ($(UNAME),Darwin)
   LD = clang
   AR := /usr/bin/ar -r -c
+  export LIBRARY_PATH = $(shell gfortran -print-search-dirs | sed -ne 's/libraries: =\(.*\)/\1/p')
 else
   LD = $(FC)
   AR := /usr/bin/ar -rc -o

--- a/Makefile.code
+++ b/Makefile.code
@@ -25,7 +25,8 @@ RANLIB ?= /usr/bin/ranlib
 ifeq ($(UNAME),Darwin)
   LD = clang
   AR := /usr/bin/ar -r -c
-  export LIBRARY_PATH = $(shell gfortran -print-search-dirs | sed -ne 's/libraries: =\(.*\)/\1/p')
+  export LIBRARY_PATH = \
+	  $(shell gfortran -print-search-dirs | sed -ne 's/libraries: =\(.*\)/\1/p')
 else
   LD = $(FC)
   AR := /usr/bin/ar -rc -o


### PR DESCRIPTION
This commit makes it possible to use the updated Makefile from @lervag on macOS without adjusting any path variables first. 

The code should now compile by typing just `gmake optim` (using the `gcc` and `make` packages installed via HomeBrew).